### PR TITLE
活動確定していない日の通知

### DIFF
--- a/backend/app/models/time_model.py
+++ b/backend/app/models/time_model.py
@@ -45,5 +45,5 @@ class ActualTimeIn(BaseModel):
         return actual_time
 
 
-class validateStatus(BaseModel):
+class ValidateStatus(BaseModel):
     status: Status

--- a/backend/app/models/time_model.py
+++ b/backend/app/models/time_model.py
@@ -43,3 +43,7 @@ class ActualTimeIn(BaseModel):
             raise ValueError("活動時間は0.5時間単位で入力してください")
 
         return actual_time
+
+
+class validateStatus(BaseModel):
+    status: Status

--- a/backend/app/routers/time.py
+++ b/backend/app/routers/time.py
@@ -2,7 +2,7 @@ import traceback
 from datetime import datetime, timedelta
 from fastapi import APIRouter, HTTPException, Depends
 from app.models.time_model import (
-    TargetTimeIn, ActualTimeIn, RegisterActivities, validateStatus
+    TargetTimeIn, ActualTimeIn, RegisterActivities, ValidateStatus
 )
 from app.models.common_model import CheckDate, CheckYear
 from db import db_model
@@ -406,7 +406,7 @@ def get_all_activities(db: Session = Depends(get_db),
 
 
 @router.get("/activities", status_code=200)
-def get_activities_by_status(param: validateStatus = Depends(),
+def get_activities_by_status(param: ValidateStatus = Depends(),
                              db: Session = Depends(get_db),
                              current_user: dict = Depends(get_current_user)):
     """ 日ごとの活動実績をステータスごとに取得 """

--- a/backend/app/routers/time.py
+++ b/backend/app/routers/time.py
@@ -417,10 +417,10 @@ def get_activities_by_status(param: validateStatus = Depends(),
             db_model.Activity.status == status).order_by(
                 db_model.Activity.date).all()
         if not activities:
-            status_dic = {"pending": "未完了", "failure": "未達成", "success": "達成"}
+            status_dic = {"pending": "未確定", "failure": "未達成", "success": "達成"}
             raise HTTPException(status_code=404,
                                 detail=f"ステータスが「{status_dic[status]}」の活動は登録されていません")
-        return activities
+        return {"activities": activities}
     except HTTPException as http_e:
         raise http_e
     except Exception:

--- a/backend/app/routers/time.py
+++ b/backend/app/routers/time.py
@@ -2,7 +2,7 @@ import traceback
 from datetime import datetime, timedelta
 from fastapi import APIRouter, HTTPException, Depends
 from app.models.time_model import (
-    TargetTimeIn, ActualTimeIn, RegisterActivities
+    TargetTimeIn, ActualTimeIn, RegisterActivities, validateStatus
 )
 from app.models.common_model import CheckDate, CheckYear
 from db import db_model
@@ -366,10 +366,10 @@ def get_year_activities(year: int,
             status_code=500, detail="サーバーでエラーが発生しました。管理者にお問い合わせください")
 
 
-@router.get("/activities/total/", status_code=200)
+@router.get("/activities/total", status_code=200)
 def get_all_activities(db: Session = Depends(get_db),
                        current_user: dict = Depends(get_current_user)):
-    """ 全期間のデータを取得 """
+    """ 全期間を集計したデータを取得 """
     try:
         # 検索範囲の指定
         activities = db.query(db_model.Activity).filter(
@@ -397,6 +397,30 @@ def get_all_activities(db: Session = Depends(get_db),
                 "penalty": total_penalty,
                 "success_days": success_days,
                 "fail_days": len(activities) - success_days}
+    except HTTPException as http_e:
+        raise http_e
+    except Exception:
+        logger.error(f"月別の活動実績の取得に失敗しました\n{traceback.format_exc()}")
+        raise HTTPException(
+            status_code=500, detail="サーバーでエラーが発生しました。管理者にお問い合わせください")
+
+
+@router.get("/activities", status_code=200)
+def get_activities_by_status(param: validateStatus = Depends(),
+                             db: Session = Depends(get_db),
+                             current_user: dict = Depends(get_current_user)):
+    """ 日ごとの活動実績をステータスごとに取得 """
+    try:
+        status = param.status
+        activities = db.query(db_model.Activity).filter(
+            db_model.Activity.username == current_user["username"],
+            db_model.Activity.status == status).order_by(
+                db_model.Activity.date).all()
+        if not activities:
+            status_dic = {"pending": "未完了", "failure": "未達成", "success": "達成"}
+            raise HTTPException(status_code=404,
+                                detail=f"ステータスが「{status_dic[status]}」の活動は登録されていません")
+        return activities
     except HTTPException as http_e:
         raise http_e
     except Exception:

--- a/backend/test/routers/test_time.py
+++ b/backend/test/routers/test_time.py
@@ -349,3 +349,26 @@ def test_get_year_acitivities(client, get_headers):
                                    "nov": {},
                                    "dec": {}
                                }}
+
+
+def test_get_acitivities_by_status(client, get_headers):
+    """ ステータスで活動を絞って取得 """
+    setup_monthly_income_for_test(client, get_headers)
+    setup_target_time_for_test(client, get_headers)
+    setup_actual_time_for_test(client, get_headers)
+    response = client.get("/activities?status=pending", headers=get_headers)
+    assert response.status_code == 200
+    assert response.json() == [{"activity_id": 1,
+                               "date": "2024-05-05",
+                                "target_time": 5.0,
+                                "actual_time": 5.0,
+                                "status": "pending",
+                                "bonus": 0.0,
+                                "penalty": 0.0,
+                                "username": test_username}]
+
+
+def test_get_acitivities_with_wrong_status(client, get_headers):
+    """ ステータス名を間違えた状態で取得 """
+    response = client.get("/activities?status=pendin", headers=get_headers)
+    assert response.status_code == 422

--- a/backend/test/routers/test_time.py
+++ b/backend/test/routers/test_time.py
@@ -358,14 +358,14 @@ def test_get_acitivities_by_status(client, get_headers):
     setup_actual_time_for_test(client, get_headers)
     response = client.get("/activities?status=pending", headers=get_headers)
     assert response.status_code == 200
-    assert response.json() == [{"activity_id": 1,
-                               "date": "2024-05-05",
-                                "target_time": 5.0,
-                                "actual_time": 5.0,
-                                "status": "pending",
-                                "bonus": 0.0,
-                                "penalty": 0.0,
-                                "username": test_username}]
+    assert response.json() == {"activities": [{"activity_id": 1,
+                                               "date": "2024-05-05",
+                                               "target_time": 5.0,
+                                               "actual_time": 5.0,
+                                               "status": "pending",
+                                               "bonus": 0.0,
+                                               "penalty": 0.0,
+                                               "username": test_username}]}
 
 
 def test_get_acitivities_with_wrong_status(client, get_headers):

--- a/frontend/src/views/ActivityHome.vue
+++ b/frontend/src/views/ActivityHome.vue
@@ -130,7 +130,11 @@
         </div>
         <br>
         <div class="container card">
-            <h5 class="card-title mt-3 clickable" @click="toggleFormVisibility">未確定の活動日</h5>
+            <h5 class="card-title mt-3 clickable" @click="toggleFormVisibility">
+                未確定の活動日
+                <span v-if="isFormVisible" class="ms-2">▲</span>
+                <span v-else class="ms-2">▼</span>
+            </h5>
             <hr class="divider">
             <div class="collapse" :class="{ 'show': isFormVisible }">
                 <div class="text-start mt-3" v-if="Object.keys(pendingActivities).length > 0">

--- a/frontend/src/views/ActivityHome.vue
+++ b/frontend/src/views/ActivityHome.vue
@@ -128,6 +128,35 @@
                 <p v-if="finMsg" class="mt-3 col-12" :class="getActivityAlert(activityStatus)">{{ finMsg }}</p>
             </div>
         </div>
+        <br>
+        <div class="container card">
+            <h5 class="card-title mt-3 clickable" @click="toggleFormVisibility">未確定の活動日</h5>
+            <hr class="divider">
+            <div class="collapse" :class="{ 'show': isFormVisible }">
+                <div class="text-start mt-3" v-if="Object.keys(pendingActivities).length > 0">
+                    <table class="table table-striped table-responsive">
+                    <thead class="table-dark">
+                        <tr>
+                        <th class="col-3">日付</th>
+                        <th>目標時間</th>
+                        <th>活動時間</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr v-for="(activity, index) in pendingActivities" :key="index">
+                        <td>{{ activity.date }}</td>
+                        <td>{{ activity.target_time }}時間</td>
+                        <td>{{ activity.actual_time }}時間</td>
+                        </tr>
+                    </tbody>
+                    </table>
+                </div>
+                <div v-if="pendingMsg" class="alert alert-success">
+                    {{ pendingMsg }}
+                </div>
+            </div>
+        </div>
+        <br>
     </div>
 
     <!-- モーダルコンポーネントで登録前の確認 -->
@@ -143,7 +172,8 @@ import { ref, watch, onMounted, computed } from 'vue';
 import { BButton, BModal } from 'bootstrap-vue-next';
 import { 
     changeDate, STATUS_DICT, getStatusColors, getToday, getMaxDate,
-    getActivityAlert, getResponseAlert, updateActivity, registerActivity, finalizeActivity } from './lib/index';
+    getActivityAlert, getResponseAlert, updateActivity, registerActivity, 
+    finalizeActivity, getActivitiesByStatus } from './lib/index';
 
 export default {
     components: {
@@ -162,6 +192,9 @@ export default {
         const finMsg = ref("");
         const activityRes = ref("");
         const activityStatus = ref("");
+        const isFormVisible = ref(false)
+        const pendingActivities = ref([]);
+        const pendingMsg = ref("")
         const tabs = [
                     { value: 'target', label: '目標時間' },
                     { value: 'actual', label: '活動時間' },
@@ -171,7 +204,12 @@ export default {
         const { renewActivity } = updateActivity(date, checkMsg, activityRes);
         const { registerTarget, registerActual } = registerActivity(date, statusCode, targetTime, actualTime, message, checkMsg, activityRes);
         const { finishActivity } = finalizeActivity(date, finMsg, activityStatus, checkMsg, activityRes);
+        const { getPendingActivities } = getActivitiesByStatus(pendingActivities, pendingMsg)
         const showModal = ref(false);
+
+        const toggleFormVisibility = () => {
+            isFormVisible.value = !isFormVisible.value
+        }
 
         const confirmRegister = async() =>{
             showModal.value = true
@@ -203,13 +241,16 @@ export default {
             if (showModal.value) {
                 switch(activeTab.value) {
                     case 'target':
-                    registerTarget();
+                    await registerTarget();
+                    await getPendingActivities();
                     break;
                 case 'actual':
-                    registerActual();
+                    await registerActual();
+                    await getPendingActivities();
                     break;
                 case 'finish':
-                    finishActivity();
+                    await finishActivity();
+                    await getPendingActivities();
                     break;
                 }
             }
@@ -229,6 +270,7 @@ export default {
 
         onMounted(() => {
             renewActivity();
+            getPendingActivities();
         });
 
     return {
@@ -243,6 +285,9 @@ export default {
             finMsg,
             activityRes,
             activityStatus,
+            pendingActivities,
+            getPendingActivities,
+            pendingMsg,
             increaseDay,
             STATUS_DICT,
             getMaxDate,
@@ -255,6 +300,8 @@ export default {
             finishActivity,
             showModal,
             confirmRegister,
+            toggleFormVisibility,
+            isFormVisible,
             modalTitle,
             modalMessage,
             sendRequest

--- a/frontend/src/views/UserInfo.vue
+++ b/frontend/src/views/UserInfo.vue
@@ -1,7 +1,11 @@
 <template>
   <h2 class="mb-5">ユーザー管理メニュー</h2>
   <div class="container col-8 card">
-    <h5 class="card-title mt-3 clickable" @click="toggleFormVisibility">パスワード変更</h5>
+    <h5 class="card-title mt-3 clickable" @click="toggleFormVisibility">
+      パスワード変更
+      <span v-if="isFormVisible" class="ms-2">▲</span>
+      <span v-else class="ms-2">▼</span>
+    </h5>
     <hr class="divider">
 
     <div class="collapse" :class="{ 'show': isFormVisible }">

--- a/frontend/src/views/lib/index.js
+++ b/frontend/src/views/lib/index.js
@@ -9,7 +9,7 @@ import { errorWithStatusCode, errorWithActivityStatus, errorWithActivity, errorW
 import { validateUsername, validatePassword, checkPassword, validateEmail } from "./userinfo";
 import { 
     updateActivity, registerActivity, finalizeActivity, 
-    getActivityByMonth, getActivityByYear, getActivitiesAllPeriod } from "./activity";
+    getActivityByMonth, getActivityByYear, getActivitiesAllPeriod, getActivitiesByStatus } from "./activity";
 
 export {
     MONTH_DICT,
@@ -43,5 +43,6 @@ export {
     finalizeActivity,
     getActivityByMonth,
     getActivityByYear,
-    getActivitiesAllPeriod
+    getActivitiesAllPeriod,
+    getActivitiesByStatus
 }


### PR DESCRIPTION
### **PR Type**
Enhancement, Tests


___

### **Description**
- 新しいAPIエンドポイントで活動をステータスごとに取得

- フロントエンドに未確定の活動日を表示する機能を追加

- バックエンドで新しいバリデーションモデルを追加

- ステータスで活動を取得するテストを追加


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>time_model.py</strong><dd><code>バリデーションモデルの追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/models/time_model.py

- 新しいバリデーションモデル`validateStatus`を追加


</details>


  </td>
  <td><a href="https://github.com/yamaoyu/application-to-study/pull/120/files#diff-35848113772f0c417c47a3f9dc79e07eff5aced8aa4d5c723c1d1725bf8c99e4">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>time.py</strong><dd><code>新しいAPIエンドポイントの追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/app/routers/time.py

- 新しいエンドポイント`get_activities_by_status`を追加
- エンドポイントの説明を修正


</details>


  </td>
  <td><a href="https://github.com/yamaoyu/application-to-study/pull/120/files#diff-cca1b4957acc2f5ffbbc8f0579867e15073d5e6680c519bfc70712c6659bb0a9">+27/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ActivityHome.vue</strong><dd><code>未確定活動日の表示機能を追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/views/ActivityHome.vue

- 未確定の活動日を表示するUIを追加
- フォームの表示切替機能を追加


</details>


  </td>
  <td><a href="https://github.com/yamaoyu/application-to-study/pull/120/files#diff-ae9a1b5237b2b9a6ae7af5743b2ae5c4c9942a425ec61147b94a4b448e2f8bf4">+51/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>activity.js</strong><dd><code>ステータスごとの活動取得ロジックを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/views/lib/activity.js

- `getActivitiesByStatus`関数を追加
- 未確定の活動日を取得するロジックを追加


</details>


  </td>
  <td><a href="https://github.com/yamaoyu/application-to-study/pull/120/files#diff-a1ef537b9c63d80e43a5f82975fb71359434fe8360fb364951339055b1a7c8c4">+48/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>index.js</strong><dd><code>新しい関数のエクスポートを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/views/lib/index.js

- `getActivitiesByStatus`をエクスポートに追加


</details>


  </td>
  <td><a href="https://github.com/yamaoyu/application-to-study/pull/120/files#diff-b2d7db61c9dd44a96b5bd8d1f1744f9a8a573fe2227b6158cfa37e57b8620493">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>test_time.py</strong><dd><code>ステータス取得のテストを追加</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

backend/test/routers/test_time.py

- 新しいテスト`test_get_acitivities_by_status`を追加
- ステータスが間違っている場合のテストを追加


</details>


  </td>
  <td><a href="https://github.com/yamaoyu/application-to-study/pull/120/files#diff-d45605ca0093a5e5b959e014a99f95f42cc6e6b6ef9386bd7780defe74b892f9">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>