### PR TITLE
活動時間登録フォームの機能追加

### DIFF
--- a/frontend/src/views/ActivityHome.vue
+++ b/frontend/src/views/ActivityHome.vue
@@ -189,7 +189,7 @@
                                 <button 
                                     type="button" 
                                     class="btn btn-primary btn-sm"
-                                    data-testid="apply-selection"
+                                    data-testid="apply-actual-selection"
                                     @click="applySelection"
                                     :disabled="selectMode === 'edited' && editedActivities.length === 0 || selectMode === 'default'"
                                 >
@@ -200,7 +200,7 @@
                                 type="button"
                                 class="btn btn-danger btn-sm"
                                 style="font-size: 0.75rem; padding: 0.15rem 0.4rem;"
-                                data-testid="reset-edited-activities"
+                                data-testid="reset-selected-activities"
                                 @click="resetEditedActivities"
                                 :disabled="editedActivities.length === 0"
                             >

--- a/frontend/test/ActivityHome.test.js
+++ b/frontend/test/ActivityHome.test.js
@@ -221,12 +221,56 @@ describe('実績時間の登録(一括)', () => {
         expect(wrapper.vm.activeTab).toEqual('actual');
         await flushPromises(); // html要素が変わるため変更を待つ
         // 初期値確認
+        expect(wrapper.vm.selectMode).toEqual("default");
+        // ドロップダウンから「全て」を選択
+        const selectForm = wrapper.find("[data-testid='select-mode']")
+        await selectForm.setValue("all");
+        expect(wrapper.vm.selectMode).toEqual("all");
         expect(wrapper.vm.selectedActivities).toEqual([]);
-        // 全て選択
-        wrapper.find("[data-testid='toggle-all-activities']").trigger("click");
+        // 選択ボタンをクリック
+        wrapper.find("[data-testid='apply-actual-selection']").trigger("click");
         expect(wrapper.vm.selectedActivities).toEqual(editActivities);
-        // 全て解除
-        wrapper.find("[data-testid='toggle-all-activities']").trigger("click");
+        // 選択を解除
+        wrapper.find("[data-testid='reset-selected-activities']").trigger("click");
+        expect(wrapper.vm.selectedActivities).toEqual([]);
+    });
+
+    it("変更分全てを選択/解除", async() =>{
+        // 初期設定
+        let editActivities = [
+            {
+                date: "2025/1/1",
+                target_time: 3,
+                actual_time: 3,
+                status: "success"
+            },
+            {
+                date: "2025/1/2",
+                target_time: 3.5,
+                actual_time: 3.5,
+                status: "pending"
+            }
+        ];
+        wrapper.vm.pendingActivities = editActivities;
+        // タブの切り替え
+        wrapper.find("[data-testid='actual']").trigger('click');
+        expect(wrapper.vm.activeTab).toEqual('actual');
+        await flushPromises(); // html要素が変わるため変更を待つ
+        // ドロップダウンから「変更分のみ」を選択
+        const selectForm = wrapper.find("[data-testid='select-mode']")
+        await selectForm.setValue("edited");
+        expect(wrapper.vm.selectMode).toEqual("edited");
+        expect(wrapper.vm.selectedActivities).toEqual([]);
+        // 選択ボタンをクリックできないことを確認(変更がないため選択対象なし)
+        const submitButton = wrapper.find("[data-testid='apply-actual-selection']");
+        expect(submitButton.attributes("disabled"));
+        // 変更してから再度選択
+        editActivities[0]["actual_time"] = 5;
+        wrapper.vm.editActivities = editActivities;
+        await submitButton.trigger("click");
+        expect(wrapper.vm.selectedActivities).toEqual([editActivities[0]]); // 変更のある1つ目のみ選択される
+        // 選択を解除
+        wrapper.find("[data-testid='reset-selected-activities']").trigger("click");
         expect(wrapper.vm.selectedActivities).toEqual([]);
     })
 


### PR DESCRIPTION
### **User description**
close #40 
close #184


___

### **PR Type**
Enhancement


___

### **Description**
- Added functionality to select only edited dates.

- Implemented reset button for edited activities.

- Introduced selection mode for activity registration.

- Updated UI components for better user interaction.


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ActivityHome.vue"] -- "Add select mode" --> B["applySelection function"]
  A -- "Add reset button" --> C["resetEditedActivities function"]
  A -- "UI updates" --> D["Select and Reset buttons"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ActivityHome.vue</strong><dd><code>Added select mode and reset functionality to ActivityHome.vue</code></dd></summary>
<hr>

frontend/src/views/ActivityHome.vue

<ul><li>Added select mode dropdown for activity selection.<br> <li> Implemented reset functionality for edited activities.<br> <li> Updated toggleAllActivities function for new logic.<br> <li> Enhanced UI with new buttons and styles.</ul>


</details>


  </td>
  <td><a href="https://github.com/yamaoyu/application-to-study/pull/186/files#diff-ae9a1b5237b2b9a6ae7af5743b2ae5c4c9942a425ec61147b94a4b448e2f8bf4">+71/-24</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

