### PR TITLE
活動登録ページを開けない #200

### DIFF
--- a/frontend/src/views/ActivityHome.vue
+++ b/frontend/src/views/ActivityHome.vue
@@ -185,7 +185,7 @@ export default {
           const thisMonth = getThisMonth();
           const dateParts = thisMonth.split("-");
           await fetchMonthlySalary(dateParts[0], dateParts[1]);
-          if (incomeRes.value?.status!==404){
+          if (incomeRes.value?.status!==200){
             router.push(
               {"path":"/register/salary",
                 "query":{incomeMsg:`${incomeMsg.value}。先に月収を登録してください`}


### PR DESCRIPTION
### **User description**
月収登録ページに移行する条件に誤りがあったため修正


___

### **PR Type**
Bug fix


___

### **Description**
- 月収取得後の判定条件を修正

- `404` ではなく `200` を正常扱いに変更

- 未登録判定の誤りで遷移できない不具合を解消


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["活動登録ページ表示"] --> B["当月の月収を取得"]
  B --> C["ステータス判定"]
  C -- "200なら登録済み" --> D["活動登録ページを継続表示"]
  C -- "200以外なら未登録" --> E["月収登録ページへ遷移"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ActivityHome.vue</strong><dd><code>月収登録済み判定の条件を修正</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

frontend/src/views/ActivityHome.vue

<ul><li>月収取得後の遷移条件を <code>status !== 404</code> から <code>status !== 200</code> に修正<br> <li> 月収が登録済みでも未登録扱いになる誤判定を解消<br> <li> <code>200</code> 応答時のみ活動登録ページを継続表示するよう調整</ul>


</details>


  </td>
  <td><a href="https://github.com/yamaoyu/application-to-study/pull/201/files#diff-ae9a1b5237b2b9a6ae7af5743b2ae5c4c9942a425ec61147b94a4b448e2f8bf4">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

