### PR TITLE
refactor #165 /loginでswaggerのフォーム形式の入力を受け取れるようにする

### DIFF
--- a/backend/app/routers/user.py
+++ b/backend/app/routers/user.py
@@ -8,7 +8,7 @@ from app.models.user_model import (RegisterUserInfo,
                                    LoginUserResponse,
                                    regenerateAccessTokenResponse,
                                    ChangePasswordInfo)
-from fastapi import APIRouter, Depends, Response, Cookie
+from fastapi import APIRouter, Depends, Response, Cookie, Request
 from app.services.user_service import UserService
 from typing import Literal
 
@@ -32,6 +32,19 @@ def get_user_service(db: Session = Depends(get_db)) -> UserService:
     return UserService(db)
 
 
+async def get_login_user_info(request: Request) -> LoginUserInfo:
+    content_type = request.headers.get("content-type", "")
+    if content_type.startswith(("application/x-www-form-urlencoded", "multipart/form-data")):
+        form = await request.form()
+        return LoginUserInfo.model_validate({
+            "username": form.get("username"),
+            "password": form.get("password"),
+        })
+
+    payload = await request.json()
+    return LoginUserInfo.model_validate(payload)
+
+
 @router.post("/users", response_model=RegisterUserResponse, status_code=201)
 def create_user(user: RegisterUserInfo, db: Session = Depends(get_db)):
     service = get_user_service(db)
@@ -47,8 +60,8 @@ def create_admin_user(user: RegisterUserInfo,
 
 
 @router.post("/login", status_code=200, response_model=LoginUserResponse)
-def login(user_info: LoginUserInfo,
-          response: Response,
+def login(response: Response,
+          user_info: LoginUserInfo = Depends(get_login_user_info),
           db: Session = Depends(get_db),
           device_id: str = Cookie(default=None)):
     service = get_user_service(db)

--- a/backend/test/routers/test_user.py
+++ b/backend/test/routers/test_user.py
@@ -112,6 +112,15 @@ def test_login(client, create_resource_owner):
         pytest.fail(f"Invalid JWT token {str(e)}")
 
 
+def test_login_with_form_data_for_swagger_ui(client, create_resource_owner):
+    user_info = {"username": RESOURCE_OWNER_USERNAME,
+                 "password": RESOURCE_OWNER_PLAIN_PASSWORD}
+    response = client.post("/login", data=user_info)
+    assert response.status_code == 200
+    assert response.json()["token_type"] == "Bearer"
+    assert "access_token" in response.json()
+
+
 def test_login_with_invalid_password(client, create_resource_owner):
     """パスワードを間違えた場合"""
     user_info = {"username": RESOURCE_OWNER_USERNAME,


### PR DESCRIPTION
swagger uiでAuthorizeできるよう、/loginにてSwagger UI の OAuth2 password flow が送るフォーム形式も受け取れるように修正

close #165 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Login now accepts credentials submitted through form data or JSON payloads.
  * Swagger UI login requests are supported and return a Bearer access token upon successful authentication.

* **Bug Fixes**
  * Improved login request handling and validation across supported formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->